### PR TITLE
Python3.7 support version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [1.0.1] - 2022-04-04
+
+### Changed
+
+- Changed Python version requirement to Python3.7 or higher
+
 ## [1.0.0] - 2022-03-25
 
 ### Added
@@ -27,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README.md initial commit
 - CHANGELOG.md initial commit
 
-[Unreleased](https://github.com/hark130/tedious-start/compare/v1.0.0...dev)
+[Unreleased](https://github.com/hark130/tedious-start/compare/v1.0.1...dev)
 
+[1.0.1](https://github.com/hark130/tedious-start/tree/v1.0.1)
 [1.0.0](https://github.com/hark130/tedious-start/tree/v1.0.0)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ TEDIOUS START (TEST): A package of common-use test functionality based on Python
 ## TEST TEDIOUS START
 
 - clone
-- pip3 install lib/hobo-1.0.0-py3-none-any.whl
+- pip3 install lib/hobo-1.0.1-py3-none-any.whl
 - Execute the example test code:
 	- `python3 -m test.example_test_start`
 	- `python3 -m test.unit_tests.example_test_unittest`

--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,12 @@ from hobo.disk_operations import destroy_dir, find_path_to_dir, read_file
 from hobo.misc import print_exception
 
 TEST_NAME = 'test'
-TEST_VERSION = '1.0.0'
+TEST_VERSION = '1.0.1'
 TEST_AUTHOR = 'Dev Crew Team Happy Aku'
 TEST_EMAIL = 'nunya@biz.ns'  # https://iiwiki.us/wiki/.ns
 TEST_DESCRIPTION = 'Common functionality used for unit and functional testing.'
 TEST_URL = 'https://github.com/hark130/tedious-start'
-TEST_PYTHON = '>=3.8'  # See: setuptools.setup(python_requires)
+TEST_PYTHON = '>=3.7'  # See: setuptools.setup(python_requires)
 TEST_REQUIRES = ['hobo>=1.0']  # See: setuptools.setup(install_requires)
 
 


### PR DESCRIPTION
Time to release a new version v1.0.1 with the following updates:

- Updated setup.py to include support for Python3.7
- Updated README with new release version
- Updated CHANGELOG with expancded support

Manually tested successfully on a Python3.7 installation using `python3 -m test.example_test_start`
