### PR TITLE
Test 21: Change `tediousstart.execute_test_cases()` behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `tediousstart.execute_test_cases()`:
+	- Value used for `unittest.main(exit)` exposed as an optional keyword argument
+	- Value used for `unittest.main(verbosity)` exposed as an optional keyword argument
+	- Default behavior of `execute_test_cases()` changed to call `sys.exit()`
+
 ### Deprecated
 
 ### Fixed

--- a/tediousstart/tediousstart.py
+++ b/tediousstart/tediousstart.py
@@ -30,12 +30,37 @@ ExceptionData = namedtuple('ExceptionData', ['exception_type', 'exception_msg'])
 # pylint:enable=undefined-variable
 
 
-def execute_test_cases():
+def execute_test_cases(sys_exit: bool = True, verbosity: int = 2) -> None:
     """Execute Test Cases.
 
-    Call this within a module to execute its Test Cases as a stand-alone collection.
+    Call this within a module to execute its Test Cases as a stand-alone collection.  See
+    unittest.main() documentation for more details on the verbosity and exit arguments.
+
+    Args:
+        sys_exit: Optional; Call sys.exit() when the test cases are complete.  This value is
+            passed to unittest.main(exit).
+        verbosity: Optional; Control the level of test case details.    This value is
+            passed to unittest.main(verbosity).
+
+            0 (quiet): Prints the total numbers of tests executed and the global result.
+            1 (standard): Same output as quiet with single characters (dot or F) for test cases.
+            2 (verbose): Prints the help string of every test and the result.
+
+    Raises:
+        TypeError: Invalid data type.
+        ValueError: Invalid value for verbosity.
     """
-    unittest.main(verbosity=2, exit=False)
+    # INPUT VALIDATION
+    validate_type(verbosity, 'verbosity', int)
+    validate_type(sys_exit, 'sys_exit', bool)
+    # Current implementation of unittest.main() treats verbosity values that exceed 2 the same
+    # as 2 so we won't restrict the upper end limit either.  Even though unittest.main()
+    # ignores(?) verbosity values less than 0, we won't stand for it here.
+    if verbosity < 0:
+        raise TypeError(f'Verbosity value of {verbosity} is not supported')
+
+    # EXECUTE THEM
+    unittest.main(verbosity=verbosity, exit=sys_exit)
 
 
 class TediousStart(unittest.TestCase):
@@ -82,7 +107,7 @@ class TediousStart(unittest.TestCase):
             method indicates an error with the test code rather than a failing test case.
 
             Args:
-                msg: Any object to wrap as a self._test_error string and self.fail() with
+                msg: Any object to wrap as a self._test_error string and self.fail() with.
 
             Returns:
                 None

--- a/tediousstart/tediousstart.py
+++ b/tediousstart/tediousstart.py
@@ -57,7 +57,7 @@ def execute_test_cases(sys_exit: bool = True, verbosity: int = 2) -> None:
     # as 2 so we won't restrict the upper end limit either.  Even though unittest.main()
     # ignores(?) verbosity values less than 0, we won't stand for it here.
     if verbosity < 0:
-        raise TypeError(f'Verbosity value of {verbosity} is not supported')
+        raise ValueError(f'Verbosity value of {verbosity} is not supported')
 
     # EXECUTE THEM
     unittest.main(verbosity=verbosity, exit=sys_exit)

--- a/test/unit_tests/test_tediousstart_execute_test_cases.py
+++ b/test/unit_tests/test_tediousstart_execute_test_cases.py
@@ -1,0 +1,109 @@
+"""Unit test the tediousstart.execute_test_cases() function.
+
+NOTE: No 'expect pass' test cases (e.g., Normal) were written as unit tests.  If
+execute_test_cases() were to run normally here, it would recursively execute these test cases and
+we don't need that.  'Expect pass' behavior was manually tested but we'll consider writing
+functional test cases to programmatically verify that behavior.
+
+Run the test cases defined in this module using any of the example commands below:
+
+    Usage:
+    python -m unittest
+    python -m unittest -k TestTESTExecuteTestCases
+    python -m test.unit_tests.test_tediousstart_execute_test_cases
+"""
+
+# Standard Imports
+from typing import Any
+# Third Party Imports
+# Local Imports
+from tediousstart.tediousstart import execute_test_cases
+from tediousstart.tediousunittest import TediousUnitTest
+
+
+class TestTESTExecuteTestCases(TediousUnitTest):
+    """TestTESTExecuteTestCases unit test class.
+
+    This class provides base functionality to run NEBS unit tests for fail_test_case().
+    """
+
+    # CORE CLASS METHODS
+    # Methods listed in call order
+    def call_callable(self) -> Any:
+        """Calls execute_test_cases().
+
+        Overrides the parent method.  Defines the way to call execute_test_cases().
+
+        Args:
+            None
+
+        Returns:
+            Return value of execute_test_cases()
+
+        Raises:
+            Exceptions raised by execute_test_cases() are bubbled up and handled by
+            TediousUnitTest
+        """
+        return execute_test_cases(*self._args, **self._kwargs)
+
+    def validate_return_value(self, return_value: Any) -> None:
+        """Validate execute_test_cases() return value.
+
+        Overrides the parent method.  Defines how the test framework validates the return value
+        of a completed call.  Calls self._validate_return_value() method under the hood.
+
+        Args:
+            return_value: This is ignored.  execute_test_cases() should return None.
+        """
+        self._validate_return_value(return_value=None)
+
+
+class ErrorTestTESTExecuteTestCases(TestTESTExecuteTestCases):
+    """Error Test Cases.
+
+    Organize the Error Test Cases.
+    """
+
+    def test_error_01(self):
+        """Bad data type: sys_exit."""
+        self.set_test_input(sys_exit='False')
+        self.expect_exception(exception_type=TypeError,
+                              exception_msg='sys_exit')
+        self.run_test()
+
+    def test_error_02(self):
+        """Bad data type: verbosity."""
+        self.set_test_input(verbosity='1')
+        self.expect_exception(exception_type=TypeError,
+                              exception_msg='verbosity')
+        self.run_test()
+
+
+class BoundaryTestTESTExecuteTestCases(TestTESTExecuteTestCases):
+    """Boundary Test Cases.
+
+    Organize the Boundary Test Cases.
+    """
+
+    def test_boundary_01(self):
+        """Barely bad verbosity value."""
+        input_verbosity = -1
+        self.set_test_input(verbosity=input_verbosity)
+        self.expect_exception(exception_type=ValueError,
+                              exception_msg=f'Verbosity value of {input_verbosity} '
+                                            'is not supported')
+        self.run_test()
+
+    def test_boundary_02(self):
+        """Very bad verbosity value."""
+        input_verbosity = -1000000000000000
+        self.set_test_input(verbosity=input_verbosity)
+        self.expect_exception(exception_type=ValueError,
+                              exception_msg=f'Verbosity value of {input_verbosity} '
+                                            'is not supported')
+        self.run_test()
+
+
+if __name__ == '__main__':
+    # Does this count as a "Normal" (see: NEBS) unit test case?
+    execute_test_cases(sys_exit=True, verbosity=2)


### PR DESCRIPTION
Exposed some hard-coded values as optional keyword arguments.
Changed the default behavior to call `sys.exit()` after executing test cases.
Updated `CHANGELOG`
Wrote some unit tests to verify 'fail' behavior
'Success' behavior manually verified