### PR TITLE
Test 23: Scripted the README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ TEDIOUS START (TEST): A package of common-use test functionality based on Python
 	- Install new wheel (see: INSTALL TEDIOUS START)
 	- Execute basic stand-alone test code using TEST: `./devops/scripts/test_installation.sh`
 - Source control new wheel
+- Remove old wheel
 - Tag main
 
 ## INSTALL TEDIOUS START

--- a/README.md
+++ b/README.md
@@ -6,11 +6,7 @@ TEDIOUS START (TEST): A package of common-use test functionality based on Python
 
 - clone
 - `pip3 install lib/hobo-1.2.0-py3-none-any.whl`
-- Execute the example test code:
-	- `python3 -m test.example_test_start`
-	- `python3 -m test.unit_tests.example_test_unittest`
-	- `python3 -m test.functional_tests.example_test_functest`
-- Execute the TEST test code: `python3 -m unittest`
+- Execute all test code: `./devops/scripts/test_local.sh`
 
 ## RELEASE TEDIOUS START
 
@@ -34,19 +30,7 @@ TEDIOUS START (TEST): A package of common-use test functionality based on Python
 - `python3 setup.py bdist_wheel --dist-dir='dist'`
 - Manually test wheel
 	- Install new wheel (see: INSTALL TEDIOUS START)
-	- Execute basic stand-alone test code using TEST
-	    1. `TediousStart`
-		    - `cp test/example_test_start.py /tmp`
-		    - `python3 /tmp/example_test_start.py`
-		2. `TediousUnitTest`
-			- `cp test/unit_tests/example_test_unittest.py /tmp`
-			- `cp --recursive badcode/ /tmp`
-			- `python3 /tmp/example_test_unittest.py`
-		3. `TediousFuncTest`
-		    - `cp test/functional_tests/example_test_functest.py /tmp`
-		    - `cp --recursive badcode/ /tmp`
-		    - `cd /tmp`
-		    - `python3 example_test_functest.py`
+	- Execute basic stand-alone test code using TEST: `./devops/scripts/test_installation.sh`
 - Source control new wheel
 - Tag main
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,8 @@ TEDIOUS START (TEST): A package of common-use test functionality based on Python
     - Update the "[Unreleased]" link at the bottom
     - Add a new version link at the bottom
 - Update setup.py with new version
-- Code review dev branch
-	- `pycodestyle --max-line-length=100 ./`
-	- `find . -type f -name "*.py" | xargs pylint --score=no --disable=duplicate-code`
-	- `find ./tediousstart/ -type f -name "*.py" | xargs pylint --score=no`
-	- Execute the TEST test code (see: TEST TEDIOUS START)
+- Code review dev branch: `./devops/scripts/review_code.sh`
+- Execute the TEST test code (see: TEST TEDIOUS START)
 - Merge dev into main
 
 ### 2. On `main` branch

--- a/devops/scripts/review_code.sh
+++ b/devops/scripts/review_code.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# DESCRIPTION:
+# This script automates the execution of various checks on the project's code base.  Reviews of
+# the test code is a bit more lenient.  All checks will be run, regardless of what is found, but
+# this script will exit with a non-zero value if any check fails.
+#
+# EXIT CODES:
+# This script uses the following exit codes:
+#   0 on success
+#   1 if any command exits with a non-zero value
+
+# GLOBAL VARIABLES
+EXIT_CODE=0          # Exit code used by this script
+ORIGINAL_DIR=$(pwd)  # Working dir of execution
+
+
+# CHECK IT
+# Pycodestyle
+pycodestyle --max-line-length=100 ./
+if [ $? -eq 0 ]
+then
+    echo -e "[✓] Pycodestyle likes the code base"
+else
+    echo -e "[X] Pycodestyle does *NOT* like the code base"
+    EXIT_CODE=1
+fi
+# Pylint (TEDIOUS START)
+find ./tediousstart/ -type f -name "*.py" | xargs pylint --score=no
+if [ $? -eq 0 ]
+then
+    echo -e "[✓] Pylint approves of TEDIOUS START"
+else
+    echo -e "[X] Pylint does *NOT* approve of TEDIOUS START"
+    EXIT_CODE=1
+fi
+# Pylint (Test Code)
+find . -type f -name "*.py" | xargs pylint --score=no --disable=duplicate-code
+if [ $? -eq 0 ]
+then
+    echo -e "[✓] Pylint is happy with the remaining Python code"
+else
+    echo -e "[X] Pylint is *NOT* happy with the remaining Python code"
+    EXIT_CODE=1
+fi
+
+
+# DONE
+cd $ORIGINAL_DIR
+echo ""
+exit $EXIT_CODE

--- a/devops/scripts/test_installation.sh
+++ b/devops/scripts/test_installation.sh
@@ -1,10 +1,19 @@
 #!/bin/bash
 
+# DESCRIPTION:
 # This script automates the stand-alone testing of a TEDIOUS START (TEST) installation.  This
 # script copies the test code and the "test local" shell script to the TEMP_DIR directory to
 # avoid the pollution of local package pollution.  This script then executes the "test local"
 # shell script there to verify the TEST installation.
-# 
+#
+# USAGE EXAMPLES:
+# 1. Default verbosity
+#   $ ./devops/scripts/test_installation.sh
+# 2. Override default verbosity
+#   $ export TEST_VERBOSITY_LEVEL=2
+#   $ ./devops/scripts/test_installation.sh
+#   $ unset TEST_VERBOSITY_LEVEL
+#
 # This script uses the following exit codes:
 #   0 on success
 #   1 if any command fails

--- a/devops/scripts/test_installation.sh
+++ b/devops/scripts/test_installation.sh
@@ -10,12 +10,24 @@
 #   1 if any command fails
 
 # GLOBAL VARIABLES
-TEMP_DIR=/tmp              # Temporary directory to execute stand-alone TEST tests
+TEMP_DIR=/tmp/test_TEST    # Temporary directory to execute stand-alone TEST tests
 EXIT_CODE=0                # Exit code used by this script
 ORIGINAL_DIRECTORY=$(pwd)  # Starting directory for this script
 
 
 # VERIFY
+# Verify TEDIOUS START is installed
+if [ $EXIT_CODE -eq 0 ]
+then
+	python -c "import test" 2> /dev/null
+	if [ $? -eq 0 ]
+	then
+	    echo -e "[✓] Verified TEDIOUS START is installed"
+	else
+	    echo -e "[X] TEDIOUS START is not installed"
+	    EXIT_CODE=1
+	fi
+fi
 
 
 # SETUP
@@ -25,7 +37,7 @@ then
 	mkdir -p $TEMP_DIR
 	if [ $? -eq 0 ]
 	then
-	    echo -e "[✓] $TEMP_DIR successfully created"
+	    echo -e "[✓] Successfully created temp working directory: $TEMP_DIR"
 	else
 	    echo -e "[X] Failed to create $TEMP_DIR"
 	    EXIT_CODE=1
@@ -90,6 +102,5 @@ fi
 
 # DONE
 cd $ORIGINAL_DIRECTORY
-unset TEST_VERBOSITY_LEVEL
 echo ""
 exit $EXIT_CODE

--- a/devops/scripts/test_installation.sh
+++ b/devops/scripts/test_installation.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# This script automates the stand-alone testing of a TEDIOUS START (TEST) installation.  This
+# script copies the test code and the "test local" shell script to the TEMP_DIR directory to
+# avoid the pollution of local package pollution.  This script then executes the "test local"
+# shell script there to verify the TEST installation.
+# 
+# This script uses the following exit codes:
+#   0 on success
+#   1 if any command fails
+
+# GLOBAL VARIABLES
+TEMP_DIR=/tmp              # Temporary directory to execute stand-alone TEST tests
+EXIT_CODE=0                # Exit code used by this script
+ORIGINAL_DIRECTORY=$(pwd)  # Starting directory for this script
+
+
+# VERIFY
+
+
+# SETUP
+# Create temp dir
+if [ $EXIT_CODE -eq 0 ]
+then
+	mkdir -p $TEMP_DIR
+	if [ $? -eq 0 ]
+	then
+	    echo -e "[✓] $TEMP_DIR successfully created"
+	else
+	    echo -e "[X] Failed to create $TEMP_DIR"
+	    EXIT_CODE=1
+	fi
+fi
+# Copy files
+if [ $EXIT_CODE -eq 0 ]
+then
+	# Necessary shell script
+	cp ./devops/scripts/test_local_examples.sh $TEMP_DIR
+	if [ $? -ne 0 ]
+	then
+	    EXIT_CODE=1
+	fi
+	# Test code
+	cp --recursive test/ $TEMP_DIR
+	if [ $? -ne 0 ]
+	then
+	    EXIT_CODE=1
+	fi
+	# Bad code (to test)
+	cp --recursive badcode/ $TEMP_DIR
+	if [ $? -ne 0 ]
+	then
+	    EXIT_CODE=1
+	fi
+	# Check it
+	if [ $EXIT_CODE -eq 0 ]
+	then
+	    echo -e "[✓] Successfully copied files"
+	else
+	    echo -e "[X] Failed to copy files"
+	fi
+fi
+# Change directory
+if [ $EXIT_CODE -eq 0 ]
+then
+	cd $TEMP_DIR
+	if [ $? -eq 0 ]
+	then
+	    echo -e "[✓] Current directory: $TEMP_DIR"
+	else
+	    echo -e "[X] Failed to change directory to $TEMP_DIR"
+	    EXIT_CODE=1
+	fi
+fi
+
+
+# TEST IT
+if [ $EXIT_CODE -eq 0 ]
+then
+	./test_local_examples.sh
+	if [ $? -eq 0 ]
+	then
+	    echo -e "[✓] TEDIOUS START (TEST) installation passed testing"
+	else
+	    echo -e "[X] TEDIOUS START (TEST) installation failed testing"
+	    EXIT_CODE=1
+	fi
+fi
+
+
+# DONE
+cd $ORIGINAL_DIRECTORY
+unset TEST_VERBOSITY_LEVEL
+echo ""
+exit $EXIT_CODE

--- a/devops/scripts/test_local.sh
+++ b/devops/scripts/test_local.sh
@@ -22,9 +22,9 @@ echo "TEST EXAMPLE USAGE"
 python3 -m test.example_test_start
 if [ $? -eq 0 ]
 then
-    echo "[✓] Example TediousStart test cases"
+    echo -e "[✓] Example TediousStart test cases\n"
 else
-    echo "[X] Example TediousStart test cases"
+    echo -e "[X] Example TediousStart test cases\n"
     EXIT_CODE=1
 fi
 
@@ -32,9 +32,9 @@ fi
 python3 -m test.unit_tests.example_test_unittest
 if [ $? -eq 0 ]
 then
-    echo "[✓] Example TediousUnitTest test cases"
+    echo -e "[✓] Example TediousUnitTest test cases\n"
 else
-    echo "[X] Example TediousUnitTest test cases"
+    echo -e "[X] Example TediousUnitTest test cases\n"
     EXIT_CODE=1
 fi
 
@@ -42,9 +42,9 @@ fi
 python3 -m test.functional_tests.example_test_functest
 if [ $? -eq 0 ]
 then
-    echo "[✓] Example TediousFuncTest test cases"
+    echo -e "[✓] Example TediousFuncTest test cases\n"
 else
-    echo "[X] Example TediousFuncTest test cases"
+    echo -e "[X] Example TediousFuncTest test cases\n"
     EXIT_CODE=1
 fi
 
@@ -53,9 +53,9 @@ echo "TEDIOUS START TEST CASES"
 python3 -m unittest
 if [ $? -eq 0 ]
 then
-    echo "[✓] TEDIOUS START (TEST) test cases"
+    echo -e "[✓] TEDIOUS START (TEST) test cases\n"
 else
-    echo "[X] TEDIOUS START (TEST) test cases"
+    echo -e "[X] TEDIOUS START (TEST) test cases\n"
     EXIT_CODE=1
 fi
 

--- a/devops/scripts/test_local.sh
+++ b/devops/scripts/test_local.sh
@@ -1,67 +1,53 @@
 #!/bin/bash
 
+# This script automates the execution of the TEDIOUS START (TEST) example code and TEST test
+# code: functional tests, unit tests.  The verbosity of these tests is controlled by the
+# TEST_VERBOSITY_LEVEL environment variable.  This script controls the value of that environment
+# variable with the UNITTEST_VERBOSITY variable.
 # 
 # This script uses the following exit codes:
 #   0 on success
 #   1 if any Python command exits with a non-zero value
 
 # GLOBAL VARIABLES
-UNITTEST_VERBOSITY=0       # Verbosity level for the test cases to execute with
 # Supported Verbosity Values
 # 0 (quiet): Prints the total numbers of tests executed and the global result.
 # 1 (standard): Same output as quiet with single characters (dot or F) for test cases.
 # 2 (verbose): Prints the help string of every test and the result.
-EXIT_CODE=0                # Exit code used by this script
-ORIGINAL_DIRECTORY=$(pwd)  # Starting directory for this script
+UNITTEST_VERBOSITY=0                                                # Test case verbosity level
+EXIT_CODE=0                                                         # Exit code used by this script
+ORIGINAL_DIR=$(pwd)                                                 # Working dir of execution
+SCRIPT_DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"  # This scripts directory
+
 
 # SETUP
 export TEST_VERBOSITY_LEVEL=$UNITTEST_VERBOSITY
 
-echo "TEST EXAMPLE USAGE"
-# TediousStart Examples
-python3 -m test.example_test_start
+
+# TEST IT
+# TEDIOUS START (TEST) Examples
+$SCRIPT_DIR/test_local_examples.sh
 if [ $? -eq 0 ]
 then
-    echo -e "[✓] Example TediousStart test cases\n"
+    echo -e "[✓] TEDIOUS START (TEST) example test cases\n"
 else
-    echo -e "[X] Example TediousStart test cases\n"
+    echo -e "[X] TEDIOUS START (TEST) example test cases\n"
     EXIT_CODE=1
 fi
-
-# TediousUnitTest Examples
-python3 -m test.unit_tests.example_test_unittest
-if [ $? -eq 0 ]
-then
-    echo -e "[✓] Example TediousUnitTest test cases\n"
-else
-    echo -e "[X] Example TediousUnitTest test cases\n"
-    EXIT_CODE=1
-fi
-
-# TediousFuncTest Examples
-python3 -m test.functional_tests.example_test_functest
-if [ $? -eq 0 ]
-then
-    echo -e "[✓] Example TediousFuncTest test cases\n"
-else
-    echo -e "[X] Example TediousFuncTest test cases\n"
-    EXIT_CODE=1
-fi
-
 
 echo "TEDIOUS START TEST CASES"
-python3 -m unittest
+python3 -m test
 if [ $? -eq 0 ]
 then
-    echo -e "[✓] TEDIOUS START (TEST) test cases\n"
+    echo -e "[✓] TEDIOUS START test cases\n"
 else
-    echo -e "[X] TEDIOUS START (TEST) test cases\n"
+    echo -e "[X] TEDIOUS START test cases\n"
     EXIT_CODE=1
 fi
 
 
 # DONE
-cd $ORIGINAL_DIRECTORY
+cd $ORIGINAL_DIR
 unset TEST_VERBOSITY_LEVEL
 echo ""
 exit $EXIT_CODE

--- a/devops/scripts/test_local.sh
+++ b/devops/scripts/test_local.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# 
+# This script uses the following exit codes:
+#   0 on success
+#   1 if any Python command exits with a non-zero value
+
+# GLOBAL VARIABLES
+UNITTEST_VERBOSITY=0       # Verbosity level for the test cases to execute with
+# Supported Verbosity Values
+# 0 (quiet): Prints the total numbers of tests executed and the global result.
+# 1 (standard): Same output as quiet with single characters (dot or F) for test cases.
+# 2 (verbose): Prints the help string of every test and the result.
+EXIT_CODE=0                # Exit code used by this script
+ORIGINAL_DIRECTORY=$(pwd)  # Starting directory for this script
+
+# SETUP
+export TEST_VERBOSITY_LEVEL=$UNITTEST_VERBOSITY
+
+echo "TEST EXAMPLE USAGE"
+# TediousStart Examples
+python3 -m test.example_test_start
+if [ $? -eq 0 ]
+then
+    echo "[✓] Example TediousStart test cases"
+else
+    echo "[X] Example TediousStart test cases"
+    EXIT_CODE=1
+fi
+
+# TediousUnitTest Examples
+python3 -m test.unit_tests.example_test_unittest
+if [ $? -eq 0 ]
+then
+    echo "[✓] Example TediousUnitTest test cases"
+else
+    echo "[X] Example TediousUnitTest test cases"
+    EXIT_CODE=1
+fi
+
+# TediousFuncTest Examples
+python3 -m test.functional_tests.example_test_functest
+if [ $? -eq 0 ]
+then
+    echo "[✓] Example TediousFuncTest test cases"
+else
+    echo "[X] Example TediousFuncTest test cases"
+    EXIT_CODE=1
+fi
+
+
+echo "TEDIOUS START TEST CASES"
+python3 -m unittest
+if [ $? -eq 0 ]
+then
+    echo "[✓] TEDIOUS START (TEST) test cases"
+else
+    echo "[X] TEDIOUS START (TEST) test cases"
+    EXIT_CODE=1
+fi
+
+
+# DONE
+cd $ORIGINAL_DIRECTORY
+unset TEST_VERBOSITY_LEVEL
+echo ""
+exit $EXIT_CODE

--- a/devops/scripts/test_local.sh
+++ b/devops/scripts/test_local.sh
@@ -1,10 +1,20 @@
 #!/bin/bash
 
+# DESCRIPTION:
 # This script automates the execution of the TEDIOUS START (TEST) example code and TEST test
 # code: functional tests, unit tests.  The verbosity of these tests is controlled by the
 # TEST_VERBOSITY_LEVEL environment variable.  This script controls the value of that environment
 # variable with the UNITTEST_VERBOSITY variable.
-# 
+#
+# USAGE EXAMPLES:
+# 1. Default verbosity
+#   $ ./devops/scripts/test_local.sh
+# 2. Override default verbosity
+#   $ export TEST_VERBOSITY_LEVEL=2
+#   $ ./devops/scripts/test_local.sh
+#   $ unset TEST_VERBOSITY_LEVEL
+#
+# EXIT CODES:
 # This script uses the following exit codes:
 #   0 on success
 #   1 if any Python command exits with a non-zero value
@@ -18,10 +28,15 @@ UNITTEST_VERBOSITY=0                                                # Test case 
 EXIT_CODE=0                                                         # Exit code used by this script
 ORIGINAL_DIR=$(pwd)                                                 # Working dir of execution
 SCRIPT_DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"  # This scripts directory
+UNSET_VAR=0                                                         # 0 false, 1 true
 
 
 # SETUP
-export TEST_VERBOSITY_LEVEL=$UNITTEST_VERBOSITY
+if [[ -z "${TEST_VERBOSITY_LEVEL}" ]]
+then
+    export TEST_VERBOSITY_LEVEL=$UNITTEST_VERBOSITY
+    UNSET_VAR=1
+fi
 
 
 # TEST IT
@@ -48,6 +63,10 @@ fi
 
 # DONE
 cd $ORIGINAL_DIR
-unset TEST_VERBOSITY_LEVEL
+if [ $UNSET_VAR -ne 0 ]
+then
+    # This script exported it so this script unsets it
+    unset TEST_VERBOSITY_LEVEL
+fi
 echo ""
 exit $EXIT_CODE

--- a/devops/scripts/test_local_examples.sh
+++ b/devops/scripts/test_local_examples.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# This script automates the execution of the TEDIOUS START (TEST) example code.
+# The verbosity of these tests is controlled by the TEST_VERBOSITY_LEVEL environment variable.
+# This script controls the value of that environment variable with the UNITTEST_VERBOSITY variable.
+# 
+# This script uses the following exit codes:
+#   0 on success
+#   1 if any Python command exits with a non-zero value
+
+# GLOBAL VARIABLES
+# Supported Verbosity Values
+# 0 (quiet): Prints the total numbers of tests executed and the global result.
+# 1 (standard): Same output as quiet with single characters (dot or F) for test cases.
+# 2 (verbose): Prints the help string of every test and the result.
+UNITTEST_VERBOSITY=0       # Verbosity level for the test cases to execute with
+EXIT_CODE=0                # Exit code used by this script
+ORIGINAL_DIRECTORY=$(pwd)  # Starting directory for this script
+
+
+# SETUP
+export TEST_VERBOSITY_LEVEL=$UNITTEST_VERBOSITY
+
+
+# TEST IT
+echo "TEDIOUS START EXAMPLE USAGE"
+# TediousStart Examples
+python3 -m test.example_test_start
+if [ $? -eq 0 ]
+then
+    echo -e "[✓] Example TediousStart test cases\n"
+else
+    echo -e "[X] Example TediousStart test cases\n"
+    EXIT_CODE=1
+fi
+
+# TediousUnitTest Examples
+python3 -m test.unit_tests.example_test_unittest
+if [ $? -eq 0 ]
+then
+    echo -e "[✓] Example TediousUnitTest test cases\n"
+else
+    echo -e "[X] Example TediousUnitTest test cases\n"
+    EXIT_CODE=1
+fi
+
+# TediousFuncTest Examples
+python3 -m test.functional_tests.example_test_functest
+if [ $? -eq 0 ]
+then
+    echo -e "[✓] Example TediousFuncTest test cases\n"
+else
+    echo -e "[X] Example TediousFuncTest test cases\n"
+    EXIT_CODE=1
+fi
+
+
+# DONE
+cd $ORIGINAL_DIRECTORY
+unset TEST_VERBOSITY_LEVEL
+echo ""
+exit $EXIT_CODE

--- a/devops/scripts/test_local_examples.sh
+++ b/devops/scripts/test_local_examples.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
 
+# DESCRIPTION:
 # This script automates the execution of the TEDIOUS START (TEST) example code.
 # The verbosity of these tests is controlled by the TEST_VERBOSITY_LEVEL environment variable.
 # This script controls the value of that environment variable with the UNITTEST_VERBOSITY variable.
-# 
+#
+# USAGE EXAMPLES:
+# 1. Default verbosity
+#   $ ./devops/scripts/test_local_examples.sh
+# 2. Override default verbosity
+#   $ export TEST_VERBOSITY_LEVEL=2
+#   $ ./devops/scripts/test_local_examples.sh
+#   $ unset TEST_VERBOSITY_LEVEL
+#
+# EXIT CODES:
 # This script uses the following exit codes:
 #   0 on success
 #   1 if any Python command exits with a non-zero value
@@ -16,10 +26,16 @@
 UNITTEST_VERBOSITY=0       # Verbosity level for the test cases to execute with
 EXIT_CODE=0                # Exit code used by this script
 ORIGINAL_DIRECTORY=$(pwd)  # Starting directory for this script
+UNSET_VAR=0                # 0 false, 1 true
+
 
 
 # SETUP
-export TEST_VERBOSITY_LEVEL=$UNITTEST_VERBOSITY
+if [[ -z "${TEST_VERBOSITY_LEVEL}" ]]
+then
+    export TEST_VERBOSITY_LEVEL=$UNITTEST_VERBOSITY
+    UNSET_VAR=1
+fi
 
 
 # TEST IT
@@ -57,6 +73,10 @@ fi
 
 # DONE
 cd $ORIGINAL_DIRECTORY
-unset TEST_VERBOSITY_LEVEL
+if [ $UNSET_VAR -ne 0 ]
+then
+    # This script exported it so this script unsets it
+    unset TEST_VERBOSITY_LEVEL
+fi
 echo ""
 exit $EXIT_CODE

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,4 +1,4 @@
 """Defines package-wide variables for the TEDIOUS START (TEST) testing."""
 # SPOT for the environment variable name used by this project's scripts to set test case verbosity.
-TEST_VERB_LEVELS = [0,1,2]                  # 0 is quiet, 1 is default, and 2 is verbose
+TEST_VERB_LEVELS = [0, 1, 2]                # 0 is quiet, 1 is default, and 2 is verbose
 TEST_ENV_VAR_NAME = 'TEST_VERBOSITY_LEVEL'  # Environment variable to test for verbosity

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,4 @@
+"""Defines package-wide variables for the TEDIOUS START (TEST) testing."""
+# SPOT for the environment variable name used by this project's scripts to set test case verbosity.
+TEST_VERB_LEVELS = [0,1,2]                  # 0 is quiet, 1 is default, and 2 is verbose
+TEST_ENV_VAR_NAME = 'TEST_VERBOSITY_LEVEL'  # Environment variable to test for verbosity

--- a/test/__main__.py
+++ b/test/__main__.py
@@ -1,8 +1,8 @@
-"""Defines the logic for running all existing unit tests as a module.
+"""Defines the logic for running all existing unittest test cases as a package.
 
     Typical usage example:
 
-    python -m test.functional_tests
+    python -m test
 """
 # Standard Imports
 import sys
@@ -14,4 +14,4 @@ from test.loader import load_and_run_dynamic
 if __name__ == '__main__':
     # Run all test cases discovered in this package
     # Exit 0 on success, 1 otherwise
-    sys.exit(not load_and_run_dynamic('test/functional_tests'))
+    sys.exit(not load_and_run_dynamic('test'))

--- a/test/example_test_start.py
+++ b/test/example_test_start.py
@@ -29,8 +29,8 @@ may be named IAW PEP8 naming standards.
 # Standard Imports
 # Third Party Imports
 # Local Imports
-from tediousstart.tediousstart import TediousStart
 from test.loader import exec_verbose_test_cases
+from tediousstart.tediousstart import TediousStart
 
 
 class TestSOMETHING(TediousStart):

--- a/test/example_test_start.py
+++ b/test/example_test_start.py
@@ -29,7 +29,8 @@ may be named IAW PEP8 naming standards.
 # Standard Imports
 # Third Party Imports
 # Local Imports
-from tediousstart.tediousstart import execute_test_cases, TediousStart
+from tediousstart.tediousstart import TediousStart
+from test.loader import exec_verbose_test_cases
 
 
 class TestSOMETHING(TediousStart):
@@ -96,4 +97,4 @@ class SpecialTestSOMETHING(TestSOMETHING):
 
 
 if __name__ == '__main__':
-    execute_test_cases()
+    exec_verbose_test_cases()

--- a/test/functional_tests/example_test_functest.py
+++ b/test/functional_tests/example_test_functest.py
@@ -32,8 +32,8 @@ from typing import Any
 import sys
 # Third Party Imports
 # Local Imports
-from tediousstart.tediousstart import execute_test_cases
 from tediousstart.tediousfunctest import TediousFuncTest
+from test.loader import exec_verbose_test_cases
 
 MAX_INT_VALUE = sys.maxsize  # https://docs.python.org/3.1/library/sys.html#sys.maxsize
 
@@ -319,4 +319,4 @@ class SpecialTestEXECUTABLE(TestEXECUTABLE):
 
 
 if __name__ == '__main__':
-    execute_test_cases()
+    exec_verbose_test_cases()

--- a/test/functional_tests/example_test_functest.py
+++ b/test/functional_tests/example_test_functest.py
@@ -32,8 +32,8 @@ from typing import Any
 import sys
 # Third Party Imports
 # Local Imports
-from tediousstart.tediousfunctest import TediousFuncTest
 from test.loader import exec_verbose_test_cases
+from tediousstart.tediousfunctest import TediousFuncTest
 
 MAX_INT_VALUE = sys.maxsize  # https://docs.python.org/3.1/library/sys.html#sys.maxsize
 

--- a/test/loader.py
+++ b/test/loader.py
@@ -17,11 +17,11 @@ test cases.
 from os import environ
 import unittest
 # Third Party Imports
+from test import TEST_ENV_VAR_NAME, TEST_VERB_LEVELS
 from hobo.disk_operations import validate_directory
 from hobo.validation import validate_type
 # Local Imports
 from tediousstart.tediousstart import execute_test_cases
-from test import TEST_ENV_VAR_NAME, TEST_VERB_LEVELS
 
 
 def determine_verbosity() -> int:

--- a/test/loader.py
+++ b/test/loader.py
@@ -14,11 +14,66 @@ test cases.
 
 
 # Standard Imports
+from os import environ
 import unittest
 # Third Party Imports
 from hobo.disk_operations import validate_directory
 from hobo.validation import validate_type
 # Local Imports
+from tediousstart.tediousstart import execute_test_cases
+from test import TEST_ENV_VAR_NAME, TEST_VERB_LEVELS
+
+
+def determine_verbosity() -> int:
+    """Determine the dynamic verbosity based on project environment variables.
+
+    This function will determine desired verbosity based on the environment variable defined
+    in test.TEST_ENV_VAR_NAME.  Only integer values contained in test.TEST_VERB_LEVELS will
+    be supported.  If the environment variable is missing or unsupported then this function
+    returns None.
+    """
+    # LOCAL VARIABLES
+    verb_level = None  # Unit test verbosity level: None indicates default verbosity value
+
+    # DETERMINE ITE
+    if TEST_ENV_VAR_NAME in environ:
+        try:
+            verb_level = int(environ.get(TEST_ENV_VAR_NAME))
+            if verb_level not in TEST_VERB_LEVELS:
+                verb_level = None
+        except ValueError:
+            verb_level = None
+
+    # DONE
+    return verb_level
+
+
+def exec_verbose_test_cases(sys_exit: bool = True) -> None:
+    """Execute test cases with dynamic verbosity.
+
+    Call this within a module to execute its Test Cases as a stand-alone collection with
+    project-defined dynamic verbosity.  Calls execute_test_cases() under the hood after
+    using determine_verbosity() to dynamically determine the desired verbosity level.
+    If missing, then execute_test_cases() will still be called with its default verbosity value.
+
+    Args:
+        sys_exit: Optional; Call sys.exit() when the test cases are complete.  This value is
+            passed to unittest.main(exit).
+
+    Raises:
+        TypeError: Invalid data type.
+    """
+    # LOCAL VARIABLES
+    verb_level = None  # Unit test verbosity level: None indicates default verbosity value
+
+    # PREPARE
+    verb_level = determine_verbosity()
+
+    # LOAD AND RUN
+    if isinstance(verb_level, int):
+        execute_test_cases(sys_exit=sys_exit, verbosity=verb_level)
+    else:
+        execute_test_cases(sys_exit=sys_exit)
 
 
 def load_and_run(dirname: str, verbosity: int = 2) -> bool:
@@ -59,3 +114,30 @@ def load_and_run(dirname: str, verbosity: int = 2) -> bool:
 
     # RUN
     return test_runner.run(test_suite).wasSuccessful()
+
+
+def load_and_run_dynamic(dirname: str) -> bool:
+    """Load and run all unittest test cases within dirname with dynamic verbosity.
+
+    Calls load_and_run() under the hood after using determine_verbosity() to dynamically determine
+    the desired verbosity level.  If missing, then load_and_run() will still be called with
+    its default verbosity value.
+
+    Args:
+        dirname: Directory, relative or absolute, to begin searching for test cases.
+    """
+    # LOCAL VARIABLES
+    ret_val = None     # Return value of load_and_run()
+    verb_level = None  # Unit test verbosity level: None indicates default verbosity value
+
+    # PREPARE
+    verb_level = determine_verbosity()
+
+    # LOAD AND RUN
+    if isinstance(verb_level, int):
+        ret_val = load_and_run(dirname=dirname, verbosity=verb_level)
+    else:
+        ret_val = load_and_run(dirname=dirname)
+
+    # DONE
+    return ret_val

--- a/test/unit_tests/__main__.py
+++ b/test/unit_tests/__main__.py
@@ -4,12 +4,14 @@
 
     python -m test.unit_tests
 """
-
-from test.loader import load_and_run
+# Standard Imports
 import sys
+# Third Party Imports
+# Local Imports
+from test.loader import load_and_run_dynamic
 
 
 if __name__ == '__main__':
     # Run all test cases discovered in this package
     # Exit 0 on success, 1 otherwise
-    sys.exit(not load_and_run('test/unit_tests'))
+    sys.exit(not load_and_run_dynamic('test/unit_tests'))

--- a/test/unit_tests/example_test_unittest.py
+++ b/test/unit_tests/example_test_unittest.py
@@ -33,8 +33,8 @@ import sys
 # Third Party Imports
 # Local Imports
 from badcode.maths import divide_it
-from tediousstart.tediousstart import execute_test_cases
 from tediousstart.tediousunittest import TediousUnitTest
+from test.loader import exec_verbose_test_cases
 
 MAX_INT_VALUE = sys.maxsize  # https://docs.python.org/3.1/library/sys.html#sys.maxsize
 
@@ -194,4 +194,4 @@ class SpecialTestCALLABLE(TestCALLABLE):
 
 
 if __name__ == '__main__':
-    execute_test_cases()
+    exec_verbose_test_cases()

--- a/test/unit_tests/example_test_unittest.py
+++ b/test/unit_tests/example_test_unittest.py
@@ -32,9 +32,9 @@ from typing import Any
 import sys
 # Third Party Imports
 # Local Imports
+from test.loader import exec_verbose_test_cases
 from badcode.maths import divide_it
 from tediousstart.tediousunittest import TediousUnitTest
-from test.loader import exec_verbose_test_cases
 
 MAX_INT_VALUE = sys.maxsize  # https://docs.python.org/3.1/library/sys.html#sys.maxsize
 


### PR DESCRIPTION
1. Wrote shell scripts to help automate:

- local testing
- installation verification
- code reviews

2. Updated `README` to reference the new shell scripts
3. Refactored underlying test framework to make better use of the recent `execute_test_caes()` refactor (see: TEST v1.3.0) and dynamic verbosity
- Added a new `exec_verbose_test_cases()` feature to `test.loader` to use an environment variable to determine test case verbosity
- Updated all test modules to use `exec_verbose_test_cases()`
- Added a new `load_and_run_dynamic()` project function to `test.loader` to wrap `tediousstart.local_and_run()` in a function that dynamically reads the environment variable to execute all test cases in a given package.
- Updated the `unit_tests` and `functional_tests` packages to use `test.loader.load_and_run_dynamic()`.
- Added a `__main__.py` to the "test" package so we could use the environment variable when executing *all* test cases.

NOTES:

- The new environment variable feature is local(?) to `tedious-start` (the project) and may not be appropriate for release.  "Let us see. - Mrs. H"
- The "test" package was given a `__main__.py` because it was easier than trying to find a way to make `python -m unittest` respond to this new environment variable.
- Overall, the "environment variable" feature was implemented to aid in the scripted execution of tests.  Verbose, the default setting, `unittest` output did not look good in my human-readable script.  I wanted to make it more quiet without redirecting the output so this is where we're at.